### PR TITLE
Slack通知導入

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,18 @@
+name: Notify in Slack CI
+on: push
+jobs:
+  slackNotification:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: general
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: 'Post Content :rocket:'
+          SLACK_TITLE: Post Title
+          SLACK_USERNAME: rtCamp
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## やったこと

- Rey Tech Myanmarのgeneral チャネルに通知する

## 参考リンク
https://github.com/marketplace/actions/slack-notify
https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository

### Slackチャネルの通知
![Screen Shot 2022-10-21 at 0 51 17](https://user-images.githubusercontent.com/28291036/196997427-98db2ffb-7bf3-4140-a1fc-f19dad9af7e8.png)