### PR TITLE
アニメを登録するMapperテストにアニメIDを外す

### DIFF
--- a/src/test/java/com/example/demo/mapper/AnimeMapperTest.java
+++ b/src/test/java/com/example/demo/mapper/AnimeMapperTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,6 +67,7 @@ public class AnimeMapperTest {
         assertThat(gintamaAnime.getId()).isNotNull();
         animeMapper.createAnime(yourNameAnime);
         assertThat(yourNameAnime.getId()).isNotNull();
+        assertTrue(yourNameAnime.getId() > gintamaAnime.getId());
     }
 
     @Test

--- a/src/test/java/com/example/demo/mapper/AnimeMapperTest.java
+++ b/src/test/java/com/example/demo/mapper/AnimeMapperTest.java
@@ -56,7 +56,8 @@ public class AnimeMapperTest {
     @DataSet(value = "anime.yml")
     @ExpectedDataSet(value = "expectedAfterInsertAnime.yml", ignoreCols = "id")
     void アニメが登録できること() {
-        animeMapper.createAnime(new Anime(3, "Gintama", "Comedy"));
+        animeMapper.createAnime(new Anime("Gintama", "Comedy"));
+        animeMapper.createAnime(new Anime("Your Name", "Romantic Fantasy"));
     }
 
     @Test

--- a/src/test/java/com/example/demo/mapper/AnimeMapperTest.java
+++ b/src/test/java/com/example/demo/mapper/AnimeMapperTest.java
@@ -6,6 +6,7 @@ import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import java.util.List;
 import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -56,8 +57,14 @@ public class AnimeMapperTest {
     @DataSet(value = "anime.yml")
     @ExpectedDataSet(value = "expectedAfterInsertAnime.yml", ignoreCols = "id")
     void アニメが登録できること() {
-        animeMapper.createAnime(new Anime("Gintama", "Comedy"));
-        animeMapper.createAnime(new Anime("Your Name", "Romantic Fantasy"));
+        Anime gintamaAnime = new Anime("Gintama", "Comedy");
+        assertThat(gintamaAnime.getId()).isNull();
+        Anime yourNameAnime = new Anime("Your Name", "Romantic Fantasy");
+        assertThat(yourNameAnime.getId()).isNull();
+        animeMapper.createAnime(gintamaAnime);
+        assertThat(gintamaAnime.getId()).isNotNull();
+        animeMapper.createAnime(yourNameAnime);
+        assertThat(yourNameAnime.getId()).isNotNull();
     }
 
     @Test

--- a/src/test/resources/datasets/expectedAfterInsertAnime.yml
+++ b/src/test/resources/datasets/expectedAfterInsertAnime.yml
@@ -11,3 +11,7 @@ anime:
     name: "Gintama"
     genre: "Comedy"
 
+  - id: 4
+    name: "Your Name"
+    genre: "Romantic Fantasy"
+


### PR DESCRIPTION
AnimeMapperの登録メソッド実行時に新しく採番されたIDが取得できることを確認してテストを修正しました。
### リクエストにIDを入れずに登録できること
![Screen Shot 2022-11-14 at 19 10 39](https://user-images.githubusercontent.com/28291036/201633593-5f5336d5-e56f-4d3b-80e4-f966e57614c1.png)
